### PR TITLE
Feature/#20 - Chaged required field

### DIFF
--- a/wadium/story/serializers.py
+++ b/wadium/story/serializers.py
@@ -4,8 +4,9 @@ from user.serializers import UserSerializer
 
 class StorySerializer(serializers.ModelSerializer):
     writer = UserSerializer(read_only=True)
-    title = serializers.CharField(max_length=100, default='Untitled', allow_blank=True)
-    body = serializers.JSONField(required=False)
+    title = serializers.CharField(max_length=100, allow_blank=True)
+    subtitle = serializers.CharField(max_length=140, allow_blank=True)
+    body = serializers.JSONField()
     featured_image = serializers.URLField(allow_blank=True)
     created_at = serializers.DateTimeField(read_only=True)
     updated_at = serializers.DateTimeField(read_only=True)


### PR DESCRIPTION
원래 버전에서 featured_image를 제외한 title, subtitle, body가 request에 없어도 story가 생성되는 것을 확인 했습니다.
생성 시 들어오는 request가 모두 동일할 필요가 있다고 생각해서 title, subtitle, body, featured_image를 모두 필수로 지정했습니다.